### PR TITLE
added crypto dependency to exat:start/0

### DIFF
--- a/src/exat.erl
+++ b/src/exat.erl
@@ -67,6 +67,7 @@ start() ->
     ok = application:ensure_started(inets, permanent),  % FIXME! Use ".rel"
     ok = application:ensure_started(xmerl, permanent),
     ok = application:ensure_started(ranch, permanent),
+    ok = application:ensure_started(crypto, permanent),
     ok = application:ensure_started(cowlib, permanent),
     ok = application:ensure_started(cowboy, permanent),
     ok = application:ensure_started(erlware_commons),


### PR DESCRIPTION
Cowboy depends on ranch and crypto, but only ranch was included in exat:start/0. This commit adds the crypto dependency.
